### PR TITLE
Add test for tagging object with same tag.

### DIFF
--- a/bluebottle/tests/tags.py
+++ b/bluebottle/tests/tags.py
@@ -11,6 +11,8 @@ class TestTags(unittest.TestCase,  ProjectTestsMixin, OrganizationTestsMixin,  U
     """ Tests for tags. """
 
     def tearDown(self):
+        # This shouldn't be necessary but the tests fail without it. There's
+        # probably a bug somewhere but it's not worth tracking down right now.
         Tag.objects.all().delete()
 
     def test_tagging_multiple_models(self):


### PR DESCRIPTION
I made this test to confirm that tagging an object with the same tag string will only create one Tag. I need this functionality in the migration of tags from the legacy database.

@dokterbob  You're up to bat!
