### PR TITLE
Show link to albums in project detail view.

### DIFF
--- a/apps/projects/tests.py
+++ b/apps/projects/tests.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from apps.bluebottle_utils.tests import UserTestsMixin, generate_slug
 from apps.organizations.tests import OrganizationTestsMixin
+from apps.media.tests import MediaTestsMixin
 
 from .models import Project, PlanPhase
 
@@ -58,7 +59,8 @@ class PlanPhaseTestMixin(object):
 
 
 
-class ProjectTests(TestCase, ProjectTestsMixin, PlanPhaseTestMixin):
+class ProjectTests(TestCase, ProjectTestsMixin, PlanPhaseTestMixin,
+                   MediaTestsMixin):
     """ Tests for projects. """
 
     def setUp(self):
@@ -89,6 +91,24 @@ class ProjectTests(TestCase, ProjectTestsMixin, PlanPhaseTestMixin):
         self.assertContains(response, self.project.title)
 
         self.assertContains(response, self.project.owner)
+
+    def test_detailviewalbums(self):
+        """
+        Test whether links to albums are displayed on a project's detail
+        view.
+        """
+
+        album = self.create_album()
+        album.save()
+
+        self.project.albums.add(album)
+
+        url = self.project.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertContains(response, album.title)
+        self.assertContains(response, album.get_absolute_url())
+
 
     def test_amounts(self):
         """ Test calculation of donation amounts """

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -26,6 +26,20 @@
 			{% endif %}
 			</p>
 
+			<h4>Albums</h4>
+			{% comment %} Use a with statement in order to prevent double queries to the database upon calling album_set.all() {% endcomment %}
+			{% with project.albums.all as albums %}
+				{% if albums %}
+					<ul>
+						{% for album in albums %}
+							<li><a href="{{ album.get_absolute_url }}">{{ album }}</a></li>
+						{% endfor %}
+					</ul>
+				{% else %}
+					No albums for this project.
+				{% endif %}
+			{% endwith %}
+
 			<h4>Owner</h4>
 			{% with project.owner.get_profile as owner_profile %}
 


### PR DESCRIPTION
This shows a bunch of links to albums from the project detail page, in order to 'proof' to the project owner that the information is there.

It should be noted that this feature awaits refactoring (or at least in the templates) in order to fit the specific use cases we might have, depending on a more definite (interaction) design.
