### PR TITLE
List multiple wallpost types in API.

### DIFF
--- a/apps/wallposts/models.py
+++ b/apps/wallposts/models.py
@@ -24,6 +24,9 @@ class WallPost(PolymorphicModel):
     object_id = models.PositiveIntegerField()
     content_object = generic.GenericForeignKey('content_type', 'object_id')
 
+    class Meta:
+        ordering = ('created',)
+
 
 class MediaWallPost(WallPost):
     # The content of the wall post.

--- a/apps/wallposts/serializers.py
+++ b/apps/wallposts/serializers.py
@@ -1,7 +1,8 @@
-from apps.drf2serializers.serializers import SorlImageField, TimeSinceField, OEmbedField
+from apps.drf2serializers.serializers import SorlImageField, TimeSinceField, OEmbedField, PolymorphicSerializer
 from django.contrib.auth.models import User
 from rest_framework import serializers
-from .models import MediaWallPost
+from .models import MediaWallPost, TextWallPost
+
 
 class AuthorSerializer(serializers.ModelSerializer):
     picture = SorlImageField('userprofile.picture', '90x90', crop='center', colorspace="GRAY")
@@ -11,8 +12,13 @@ class AuthorSerializer(serializers.ModelSerializer):
         fields = ('id', 'first_name', 'last_name', 'picture')
 
 
-# Note: There is no separate list and detail serializer for WallPosts (at least not yet).
-class MediaWallPostSerializer(serializers.ModelSerializer):
+class WallPostChildSerializer(serializers.ModelSerializer):
+    author = AuthorSerializer()
+    timesince = TimeSinceField(source='created')
+
+
+# Note: There is no separate list and detail serializer for MediaWallPosts
+class MediaWallPostSerializer(WallPostChildSerializer):
     author = AuthorSerializer()
     timesince = TimeSinceField(source='created')
     video_url = serializers.URLField()
@@ -21,3 +27,22 @@ class MediaWallPostSerializer(serializers.ModelSerializer):
     class Meta:
         model = MediaWallPost
         fields = ('author', 'title', 'text', 'timesince', 'video_html')
+
+
+# Note: There is no separate list and detail serializer for TextWallPosts.
+class TextWallPostSerializer(WallPostChildSerializer):
+    video_url = serializers.URLField()
+    video_html = OEmbedField(source='video_url', maxwidth='560', maxheight='315')
+
+    class Meta:
+        model = TextWallPost
+        fields = ('author', 'text', 'timesince')
+
+
+class WallPostSerializer(PolymorphicSerializer):
+
+    class Meta:
+        child_models = (
+            (TextWallPost, TextWallPostSerializer),
+            (MediaWallPost, MediaWallPostSerializer),
+            )

--- a/apps/wallposts/views.py
+++ b/apps/wallposts/views.py
@@ -1,16 +1,16 @@
 from rest_framework import generics
-from .serializers import MediaWallPostSerializer
+from .serializers import WallPostSerializer
 from .models import WallPost
 
 
 class WallPostList(generics.ListAPIView):
     model = WallPost
-    serializer_class = MediaWallPostSerializer
+    serializer_class = WallPostSerializer
     paginate_by = 10
 
 
 class WallPostDetail(generics.RetrieveAPIView):
     model = WallPost
-    serializer_class = MediaWallPostSerializer
+    serializer_class = WallPostSerializer
 
 


### PR DESCRIPTION
This pull request adds the ability to list multiple wallpost types in the same resource location.

TESTING INSTRUCTIONS
- Create a media wall post and a text wall post for a project and check the API to see the combined output.

This still needs the a type field but I want to do that when I enable write support.
