### PR TITLE
Escape HTML and JS in wallposts and reactions.

### DIFF
--- a/apps/wallposts/serializers.py
+++ b/apps/wallposts/serializers.py
@@ -61,6 +61,7 @@ class MediaWallPostSerializer(WallPostSerializerBase):
     """
 
     type = WallPostTypeField(type='media')
+    text = ContentTextField(required=False)
     video_html = OEmbedField(source='video_url', maxwidth='560', maxheight='315')
     # This is temporary and will go away when we figure out how to upload related photos.
     photo = SorlImageField('photo', '529x296', required=False)


### PR DESCRIPTION
BB-130 #resolve #comment This is now fixed and can be tested on the dev server.
