### PR TITLE
Remove PolymorphicManager from Cowry Models.

### DIFF
--- a/apps/cowry/models.py
+++ b/apps/cowry/models.py
@@ -3,7 +3,6 @@ from django.utils.translation import ugettext as _
 from django_extensions.db.fields import ModificationDateTimeField, CreationDateTimeField
 from djchoices import DjangoChoices, ChoiceItem
 from polymorphic import PolymorphicModel
-from polymorphic.manager import PolymorphicManager
 
 
 class Payment(PolymorphicModel):
@@ -34,6 +33,3 @@ class Payment(PolymorphicModel):
 
     created = CreationDateTimeField(_("created"))
     updated = ModificationDateTimeField(_("updated"))
-
-    # Manager
-    objects = PolymorphicManager()

--- a/apps/cowry_docdata/models.py
+++ b/apps/cowry_docdata/models.py
@@ -3,8 +3,7 @@ from django.db import models
 from django.utils.translation import ugettext as _
 from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
 from django_countries import CountryField
-from polymorphic.manager import PolymorphicManager
-from polymorphic.polymorphic_model import PolymorphicModel
+from polymorphic import PolymorphicModel
 
 
 class DocDataPaymentOrder(Payment):
@@ -43,8 +42,6 @@ class DocDataPayment(PolymorphicModel):
     docdata_payment_method = models.CharField(max_length=20, default='', blank=True)
     created = CreationDateTimeField(_("created"))
     updated = ModificationDateTimeField(_("updated"))
-
-    objects = PolymorphicManager()
 
 
 class DocDataWebMenu(DocDataPayment):


### PR DESCRIPTION
Specifying PolymorphicManager is not needed because it's the default manager
for PolymorphicModels.
