### PR TITLE
Remove ember-bootstrap.js reference in base.html.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,6 @@
         {# Other libs #}
         <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/bootstrap/bootstrap-transition.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/bootstrap/bootstrap-modal.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/ember-bootstrap-0.0.1.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/bootbox.js"></script>
 
         {# Plugins #}


### PR DESCRIPTION
The file wasn't actually included so it was causing problems with
django_compressor on testing and staging.
