### PR TITLE
Remove bootstrap-lightbox.js reference in base.html.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,11 +42,9 @@
         <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/bootbox.js"></script>
 
         {# Plugins #}
-        <script type="text/javascript" src="{{ STATIC_URL }}js/plugins/bootstrap-lightbox.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/plugins/jquery.infieldlabel.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/plugins/jquery.colorbox.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/plugins/handlebars.helpers.js"></script>
-
 
         {# BlueBottle Application #}
         <script type="text/javascript" src="{{ STATIC_URL }}js/app.js"></script>


### PR DESCRIPTION
Again, the file wasn't actually included so it was causing problems with
django_compressor on testing and staging.
