### PR TITLE
Use json encoded put in tests

### DIFF
--- a/apps/accounts/tests.py
+++ b/apps/accounts/tests.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 from apps.bluebottle_utils.tests import UserTestsMixin
-from django.test.client import BOUNDARY, encode_multipart, MULTIPART_CONTENT
 from rest_framework import status
-
+import json
 
 class UserApiIntegrationTest(UserTestsMixin, TestCase):
     """
@@ -29,12 +28,12 @@ class UserApiIntegrationTest(UserTestsMixin, TestCase):
 
         # Profile should not be able to be updated by anonymous users.
         full_name = {'first_name': 'Nijntje', 'last_name': 'het Konijntje'}
-        response = self.client.put(user_profile_url, encode_multipart(BOUNDARY, full_name), MULTIPART_CONTENT)
+        response = self.client.put(user_profile_url, json.dumps(full_name), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
 
         # Profile should be able to be updated by logged in user.
         self.client.login(username=self.some_user.email, password='password')
-        response = self.client.put(user_profile_url, encode_multipart(BOUNDARY, full_name), MULTIPART_CONTENT)
+        response = self.client.put(user_profile_url, json.dumps(full_name), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(response.data['first_name'], full_name.get('first_name'))
         self.assertEqual(response.data['last_name'], full_name.get('last_name'))
@@ -90,7 +89,7 @@ class UserApiIntegrationTest(UserTestsMixin, TestCase):
         self.assertFalse(response.data['newsletter'])
 
         # Test that the settings can be updated.
-        response = self.client.put(new_user_settings_url, encode_multipart(BOUNDARY, {'newsletter': True}), MULTIPART_CONTENT)
+        response = self.client.put(new_user_settings_url, json.dumps({'newsletter': True}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertTrue(response.data['newsletter'])
 

--- a/apps/projects/tests.py
+++ b/apps/projects/tests.py
@@ -3,14 +3,13 @@ from datetime import timedelta
 from django.core.exceptions import ValidationError
 from django.test import TestCase, RequestFactory
 from django.contrib.contenttypes.models import ContentType
-from django.test.client import MULTIPART_CONTENT, encode_multipart, BOUNDARY
 from django.utils import timezone
 from rest_framework import status
 from apps.bluebottle_utils.tests import UserTestsMixin, generate_random_slug
 from apps.organizations.tests import OrganizationTestsMixin
 from apps.wallposts.models import TextWallPost
 from .models import Project, IdeaPhase, FundPhase, ActPhase, ResultsPhase, AbstractPhase, ProjectPhases
-
+import json
 
 class ProjectTestsMixin(OrganizationTestsMixin, UserTestsMixin):
     """ Mixin base class for tests using projects. """
@@ -334,7 +333,7 @@ class ProjectWallPostApiIntegrationTest(ProjectTestsMixin, UserTestsMixin, TestC
 
         # Update the created Project Media WallPost by author.
         new_wallpost_title = 'This is my super-duper project!'
-        response = self.client.put(project_wallpost_detail_url, encode_multipart(BOUNDARY, {'title': new_wallpost_title, 'project': self.some_project.slug}), MULTIPART_CONTENT)
+        response = self.client.put(project_wallpost_detail_url, json.dumps({'title': new_wallpost_title, 'project': self.some_project.slug}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(response.data['title'], new_wallpost_title)
 
@@ -408,7 +407,7 @@ class ProjectWallPostApiIntegrationTest(ProjectTestsMixin, UserTestsMixin, TestC
         some_wallpost_detail_url = "{0}{1}".format(self.project_media_wallposts_url, some_wallpost_id)
 
         # Try to connect the photo to this new wallpost
-        response = self.client.put(some_photo_detail_url, encode_multipart(BOUNDARY, {'mediawallpost': some_wallpost_id}), MULTIPART_CONTENT)
+        response = self.client.put(some_photo_detail_url, json.dumps({'mediawallpost': some_wallpost_id}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
         # check that the wallpost now has 1 photo
@@ -441,7 +440,7 @@ class ProjectWallPostApiIntegrationTest(ProjectTestsMixin, UserTestsMixin, TestC
         # Make sure the first user can't connect it's picture to someone else's wallpost
         self.client.logout()
         self.client.login(username=self.some_project.owner.email, password='password')
-        response = self.client.put(another_photo_detail_url, encode_multipart(BOUNDARY, {'mediawallpost': another_wallpost_id}), MULTIPART_CONTENT)
+        response = self.client.put(another_photo_detail_url, json.dumps({'mediawallpost': another_wallpost_id}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
 
         #  Create a text wallpost. Adding a photo to that should be denied.
@@ -450,11 +449,11 @@ class ProjectWallPostApiIntegrationTest(ProjectTestsMixin, UserTestsMixin, TestC
                                     {'text': text, 'project': self.another_project.slug})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         text_wallpost_id = response.data['id']
-        response = self.client.put(another_photo_detail_url, encode_multipart(BOUNDARY, {'mediawallpost': another_wallpost_id}), MULTIPART_CONTENT)
+        response = self.client.put(another_photo_detail_url, json.dumps({'mediawallpost': another_wallpost_id}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
 
         # Add that second photo to our first wallpost and verify that will now contain two photos.
-        response = self.client.put(another_photo_detail_url, encode_multipart(BOUNDARY, {'mediawallpost': some_wallpost_id}), MULTIPART_CONTENT)
+        response = self.client.put(another_photo_detail_url, json.dumps({'mediawallpost': some_wallpost_id}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         response = self.client.get(some_wallpost_detail_url)
         self.assertEqual(len(response.data['photos']), 2)
@@ -512,7 +511,7 @@ class ProjectWallPostApiIntegrationTest(ProjectTestsMixin, UserTestsMixin, TestC
         # Update TextWallPost by author is allowed
         text2a = 'I like this project!'
         wallpost_detail_url = "{0}{1}".format(self.project_text_wallposts_url, str(response.data['id']))
-        response = self.client.put(wallpost_detail_url, encode_multipart(BOUNDARY, {'text': text2a, 'project': self.some_project.slug}), MULTIPART_CONTENT)
+        response = self.client.put(wallpost_detail_url, json.dumps( {'text': text2a, 'project': self.some_project.slug}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertTrue(text2a in response.data['text'])
 

--- a/apps/wallposts/tests.py
+++ b/apps/wallposts/tests.py
@@ -1,8 +1,8 @@
 from apps.bluebottle_utils.tests import UserTestsMixin
 from apps.projects.tests import ProjectWallPostTestsMixin
 from django.test import TestCase
-from django.test.client import encode_multipart, BOUNDARY, MULTIPART_CONTENT
 from rest_framework import status
+import json
 
 
 class WallPostReactionApiIntegrationTest(ProjectWallPostTestsMixin, TestCase):
@@ -40,7 +40,7 @@ class WallPostReactionApiIntegrationTest(ProjectWallPostTestsMixin, TestCase):
 
         # Update the created Reaction by author.
         new_reaction_text = 'HEAR!!! HEAR!!!'
-        response = self.client.put(reaction_detail_url, encode_multipart(BOUNDARY, {'text': new_reaction_text, 'wallpost': self.some_wallpost.id}), MULTIPART_CONTENT)
+        response = self.client.put(reaction_detail_url, json.dumps({'text': new_reaction_text, 'wallpost': self.some_wallpost.id}), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertTrue(new_reaction_text in response.data['text'])
 


### PR DESCRIPTION
Slightly more readiable and probably closer to how we'll be using the api
