### PR TITLE
Return 0 in EuroField when value is None.

### DIFF
--- a/apps/bluebottle_drf2/serializers.py
+++ b/apps/bluebottle_drf2/serializers.py
@@ -284,9 +284,13 @@ class ObjectBasedSerializer(serializers.Serializer):
 class EuroField(serializers.WritableField):
     # Note: You need to override save and set the currency to 'EUR' in the Serializer where this is used.
     def to_native(self, value):
+        # Convert model instance int -> text for reading.
         return '{0}.{1}'.format(str(value)[:-2], str(value)[-2:])
 
     def from_native(self, value):
+        # Convert text -> model instance int for writing.
+        if not value:
+            return 0
         return int(decimal.Decimal(value) * 100)
 
 


### PR DESCRIPTION
This fixes and issue with /api/fund/recurringdirectdebitpayments/.

```
[Django] ERROR (EXTERNAL IP): Internal Server Error: /api/fund/recurringdirectdebitpayments/

Traceback (most recent call last):

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(*args, **kwargs)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/views.py", line 327, in dispatch
    response = self.handle_exception(exc)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/views.py", line 324, in dispatch
    response = handler(request, *args, **kwargs)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/generics.py", line 426, in post
    return self.create(request, *args, **kwargs)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/mixins.py", line 50, in create
    if serializer.is_valid():

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/serializers.py", line 479, in is_valid
    return not self.errors

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/serializers.py", line 471, in errors
    ret = self.from_native(data, files)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/serializers.py", line 867, in from_native
    instance = super(ModelSerializer, self).from_native(data, files)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/serializers.py", line 317, in from_native
    attrs = self.restore_fields(data, files)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/serializers.py", line 243, in restore_fields
    field.field_from_native(data, files, field_name, reverted_data)

  File "/var/www/onepercentsite/env/lib/python2.6/site-packages/rest_framework/fields.py", line 312, in field_from_native
    value = self.from_native(native)

  File "/var/www/onepercentsite/apps/bluebottle_drf2/serializers.py", line 290, in from_native
    return int(decimal.Decimal(value) * 100)

  File "/usr/lib/python2.6/decimal.py", line 651, in __new__
    raise TypeError("Cannot convert %r to Decimal" % value)

TypeError: Cannot convert None to Decimal
```
