### PR TITLE
Deal with lang-country codes (e.g. 'en-us') in money l10n.

### DIFF
--- a/apps/cowry_docdata/admin.py
+++ b/apps/cowry_docdata/admin.py
@@ -31,7 +31,7 @@ class DocDataPaymentOrderAdmin(admin.ModelAdmin):
     inlines = (DocDataPaymentInline, DocDataPaymentLogEntryInine)
 
     def amount_override(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.amount / 100, obj.currency, locale=language)
 
     amount_override.short_description = 'amount'

--- a/apps/fund/admin.py
+++ b/apps/fund/admin.py
@@ -30,7 +30,7 @@ class DonationAdmin(admin.ModelAdmin):
     view_order.allow_tags = True
 
     def amount_override(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.amount / 100, obj.currency, locale=language)
 
     amount_override.short_description = 'amount'
@@ -63,7 +63,7 @@ class DocDataPaymentOrderInline(admin.TabularInline):
     readonly_fields = fields
 
     def amount_override(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.amount / 100, obj.currency, locale=language)
 
     amount_override.short_description = 'amount'
@@ -111,7 +111,7 @@ class OrderAdmin(admin.ModelAdmin):
     inlines = (OrderItemInline, DocDataPaymentOrderInline,)
 
     def total(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.total / 100, 'EUR', locale=language)
 
     def type(self, obj):
@@ -134,7 +134,7 @@ class VoucherAdmin(admin.ModelAdmin):
                                 'receiver_name', 'sender_name', 'message')
 
     def amount_override(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.amount / 100, obj.currency, locale=language)
 
     amount_override.short_description = 'amount'
@@ -157,7 +157,7 @@ class RecurringDirectDebitPaymentAdmin(admin.ModelAdmin):
     readonly_fields = ('created', 'updated')
 
     def amount_override(self, obj):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return format_currency(obj.amount / 100, obj.currency, locale=language)
 
     amount_override.short_description = 'amount'

--- a/apps/fund/models.py
+++ b/apps/fund/models.py
@@ -119,7 +119,7 @@ class Donation(models.Model):
         verbose_name_plural = _("donations")
 
     def __unicode__(self):
-        language = translation.get_language()
+        language = translation.get_language().split('-')[0]
         return u'{0} : {1} : {2}'.format(str(self.id), self.project.title,
                                          format_currency(self.amount / 100, self.currency, locale=language))
 


### PR DESCRIPTION
Without this change, the server will 500 error in the Admin if get_language() returns lang-country (e.g. 'en-us') instead of just lang (e.g. 'en').
