### PR TITLE
Fixed a typo causing Javascript errors in Ember-data

### DIFF
--- a/static/global/js/vendor/ember-data-drf2-adapter.js
+++ b/static/global/js/vendor/ember-data-drf2-adapter.js
@@ -378,7 +378,7 @@ DS.DRF2Adapter.registerTransform("date", {
  * This is used in accounts/models.js
  * TODO: find cleaner approach?
  */
-DS.RF2Adapter.registerTransform("birthdate", {
+DS.DRF2Adapter.registerTransform("birthdate", {
     deserialize: function(serialized) {
         if (serialized == undefined) {
             return null;


### PR DESCRIPTION
Birthdate transform was not registered because of a typo.
