### PR TITLE
Proper Bitbucket requirement plus newline fixup.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ django_countries==1.5
 requests==1.2.3
 # This version should be considered suds-jurko 0.4.1 jurko pre 5.
 # This is just a fork of the official repo in case it disappears.
-https://bitbucket.org/onepercentclub/suds/get/afe727f50704.zip
+-e hg+https://bitbucket.org/onepercentclub/suds@afe727f50704#egg=suds
 
 django-iban==0.2.1
 


### PR DESCRIPTION
Somehow, installing the suds requirement from the ZIP yielded an error:

```
Downloading/unpacking https://bitbucket.org/onepercentclub/suds/get/afe727f50704.zip (from -r requirements.txt (line 103))
  Downloading afe727f50704.zip (unknown size): 219kB downloaded
  Storing download in cache at /Users/drbob/.pip/download_cache/https%3A%2F%2Fbitbucket.org%2Fonepercentclub%2Fsuds%2Fget%2Fafe727f50704.zip
  Running setup.py egg_info for package from https://bitbucket.org/onepercentclub/suds/get/afe727f50704.zip
    ERROR: Suds library setup script needs to be run from the folder containing it.
    ()
    Current folder: /private/var/folders/8l/3px4b1wx51l3955dvhgybtgc0000gn/T/pip-OkCQPU-build
    Script folder: /var/folders/8l/3px4b1wx51l3955dvhgybtgc0000gn/T/pip-OkCQPU-build
    Complete output from command python setup.py egg_info:
    ERROR: Suds library setup script needs to be run from the folder containing it.
```

Installing directly from BitBucket solved the issue (for me).
