### PR TITLE
Only update money donated when amount_asked isn't null

### DIFF
--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -102,7 +102,7 @@ class Project(BaseProject):
     is_campaign = models.BooleanField(default=False, help_text=_("Project is part of a campaign and gets special promotion."))
 
     # For convenience and performance we also store money donated and needed here.
-    amount_asked = MoneyField(default=0)
+    amount_asked = MoneyField(default=0, null=True, blank=True)
     amount_donated = MoneyField(default=0)
     amount_needed = MoneyField(default=0)
 
@@ -325,7 +325,9 @@ class Project(BaseProject):
             self.status = ProjectPhase.objects.get(slug="done-incomplete")
             self.campaign_ended = self.deadline
 
-        self.update_money_donated(False)
+        if self.amount_asked:
+            self.update_money_donated(False)
+
         super(Project, self).save(*args, **kwargs)
 
 

--- a/onepercentclub/settings/base.py
+++ b/onepercentclub/settings/base.py
@@ -17,6 +17,7 @@ PROJECT_ROOT = os.path.dirname(os.path.normpath(os.path.join(__file__, '..', '..
 DJANGO_PROJECT = os.path.basename(PROJECT_ROOT.rstrip('/'))
 
 DEBUG = True
+TEST_MEMCACHE = False
 TEMPLATE_DEBUG = True
 
 ADMINS = (
@@ -141,13 +142,21 @@ CACHES = {
 }
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = [
-    ('django.template.loaders.cached.Loader', (
+if not DEBUG or TEST_MEMCACHE:
+    TEMPLATE_LOADERS = [
+        ('django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+            'apptemplates.Loader', # extend AND override templates
+        )),
+    ]
+else:
+    TEMPLATE_LOADERS = [
         'django.template.loaders.filesystem.Loader',
         'django.template.loaders.app_directories.Loader',
         'apptemplates.Loader', # extend AND override templates
-    )),
-]
+    ]
+
 
 # These are basically the default values from the Django configuration, written
 # as a list for easy manipulation. This way one can:


### PR DESCRIPTION
Ember allows null amount_asked when creating the project. This fix ensures the api doesn't bomb when saving a project with a null amount_asked.

Also, add a change so that templates aren't cached in development unless TEST_MEMCACHE = True.
