### PR TITLE
Use project phase sequence id for identifying status

### DIFF
--- a/apps/projects/static/js/projects/models.js
+++ b/apps/projects/static/js/projects/models.js
@@ -19,11 +19,15 @@ App.Project.reopen({
 
     task_count: DS.attr('number'),
 
-    isFundable: Em.computed.equal('status.id', 5),
-    isStatusPlan: Em.computed.lt('status.id', 5),
-    isStatusCampaign: Em.computed.equal('status.id', 5),
-    isStatusCompleted: Em.computed.equal('status.id', 7),
-    isStatusStopped: Em.computed.gt('status.id', 9),
+    isFundable: Em.computed.equal('phaseNum', 5),
+
+    isStatusPlan: Em.computed.lt('phaseNum', 5),
+    
+    isStatusCampaign: Em.computed.equal('phaseNum', 5),
+    
+    isStatusCompleted: Em.computed.equal('phaseNum', 7),
+    
+    isStatusStopped: Em.computed.gt('phaseNum', 9),
 
     isSupportable: function () {
         var now = new Date();


### PR DESCRIPTION
This is how we are setting these properties in BB and Booking. Status.id can return a number or string which is messing with the computed properties.
