### PR TITLE
Dont merge until Booking/1% bluebottle are synced

### DIFF
--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -94,7 +94,6 @@ class Project(BaseProject):
                     "explains your project? Cool! We can't wait to see it! "
                     "You can paste the link to YouTube or Vimeo video here"))
 
-    deadline = models.DateTimeField(_('deadline'), null=True, blank=True)
     popularity = models.FloatField(null=False, default=0)
     is_campaign = models.BooleanField(default=False, help_text=_("Project is part of a campaign and gets special promotion."))
 


### PR DESCRIPTION
This PR removes the deadline field from the model definition in 1%Club. A migration shouldn't be needed because the newest Bluebottle will have the deadline field in the abstract base class of a project.
