### PR TITLE
Fix for header issue in Salesforce User CSV export

### DIFF
--- a/apps/bluebottle_salesforce/export.py
+++ b/apps/bluebottle_salesforce/export.py
@@ -170,6 +170,8 @@ def generate_users_csv_file(path, loglevel):
                             "Account_number__c",
                             "Account_holder__c",
                             "Account_city__c",
+                            "Account_IBAN__c",
+                            "Account_Active_Recurring_Debit__c",
                             "Phone"])
 
         users = USER_MODEL.objects.all()


### PR DESCRIPTION
Fix for some missing headers in the User CSV export for the weekly Salesforce load. Due to this issue IBAN bank numbers are loaded in the wrong field in Salesforce (Phone).
