### PR TITLE
Feature/club 1095

### DIFF
--- a/translations.sh
+++ b/translations.sh
@@ -29,7 +29,7 @@ COMPILEJSMESSAGES="$MANAGE_PY compilejsi18n $SETTINGS"
 APPS_DIR="apps"
 
 # All apps that hold translations. This is used by `pull` and `compile`.
-APPS="projects members fundraisers organizations tasks homepage donations widget"
+APPS="projects members fundraisers organizations tasks homepage donations widget core"
 
 case "$1" in
         generate)


### PR DESCRIPTION
Update to translation script in 1%Club to generate translation strings for the new payments and donations apps in Bluebottle.

The translations are stored in the "Core' app in the 1%Club/apps dir. This resource doesn't exist yet (on Transifex) but it will be automatically created with the first push to the Transifex server.

Finally, master/develop and the dev/donations are to much apart (many merge conflicts). Therefore, the translations of the dev/donations branch is not pushed to Transifex yet.
