### PR TITLE
Salesforce donations export fix, project partner organization removal fix

### DIFF
--- a/apps/bluebottle_salesforce/sync.py
+++ b/apps/bluebottle_salesforce/sync.py
@@ -330,7 +330,7 @@ def sync_projects(dry_run, sync_from_datetime, loglevel):
             sfproject.tags = str(tag) + ", " + sfproject.tags
         sfproject.tags = sfproject.tags[:255]
 
-        sfproject.partner_organization = ""
+        sfproject.partner_organization = "-"
         if project.partner_organization:
             sfproject.partner_organization = project.partner_organization.name
 


### PR DESCRIPTION
Contains a fix for a breaking issue with the export.py code for the donations CSV file and a fix for project partner organizations in case the partner organization is manually removed from the project in the backoffice.